### PR TITLE
Crypt::OpenSSL::Guess is required at configure phase

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,9 +38,11 @@ WriteMakefile(
                 recommends => {
                     'Crypt::OpenSSL::Bignum' => 0,
                 },
-                build_requires => {
-                    'Test'                  => 0,    # For testing
+                configure_requires => {
                     'Crypt::OpenSSL::Guess' => 0,
+                },
+                build_requires => {
+                    'Test' => 0,    # For testing
                 },
                 resources => {
                     'license'    => 'http://dev.perl.org/licenses/',


### PR DESCRIPTION
This PR fixes a mistake at #3, Crypt::OpenSSL::Guess must be installed before executing Makefile.PL.
(resolves #10)