### PR TITLE
add library paths to LIBS from Crypt::OpenSSL::Guess

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,7 +39,7 @@ WriteMakefile(
                     'Crypt::OpenSSL::Bignum' => 0,
                 },
                 configure_requires => {
-                    'Crypt::OpenSSL::Guess' => '0.10',
+                    'Crypt::OpenSSL::Guess' => '0.11',
                 },
                 build_requires => {
                     'Test' => 0,    # For testing

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@ use warnings;
 
 use 5.006;
 use ExtUtils::MakeMaker 6.48;
-use Crypt::OpenSSL::Guess qw(openssl_inc_paths);
+use Crypt::OpenSSL::Guess qw(openssl_inc_paths openssl_lib_paths);
 
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
@@ -22,7 +22,7 @@ WriteMakefile(
         'Test::More'             => 0,
     },
     'OBJECT' => 'RSA.o',
-    'LIBS'   => ( $^O eq 'MSWin32' ) ? ['-lssl32 -leay32'] : ['-lssl -lcrypto'],
+    'LIBS'   => ( $^O eq 'MSWin32' ) ? [openssl_lib_paths() . ' -lssl32 -leay32'] : [openssl_lib_paths() . ' -lssl -lcrypto'],
     'DEFINE' => '-DPERL5 -DOPENSSL_NO_KRB5',
 
     # perl-5.8/gcc-3.2 needs -DPERL5, and redhat9 likes -DOPENSSL_NO_KRB5
@@ -39,7 +39,7 @@ WriteMakefile(
                     'Crypt::OpenSSL::Bignum' => 0,
                 },
                 configure_requires => {
-                    'Crypt::OpenSSL::Guess' => 0,
+                    'Crypt::OpenSSL::Guess' => '0.10',
                 },
                 build_requires => {
                     'Test' => 0,    # For testing

--- a/t/z_pod-coverage.t
+++ b/t/z_pod-coverage.t
@@ -3,7 +3,10 @@ use strict;
 use warnings;
 use Test::More;
 
-plan skip_all => 'done_testing requires Test::More 0.88' if Test::More->VERSION < 0.88;
+BEGIN {
+    plan skip_all => 'done_testing requires Test::More 0.88' if Test::More->VERSION < 0.88;
+}
+
 plan skip_all => 'This test is only run for the module author'
   unless -d '.git' || $ENV{IS_MAINTAINER};
 


### PR DESCRIPTION
This PR fixes that library paths must be specified to be linked the library with `openssl_inc_paths`.