### PR TITLE
Support strawberry perl 5.26

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,5 @@
 Changes
+hints/MSWin32.pl
 LICENSE
 Makefile.PL
 MANIFEST

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,8 +8,6 @@ use Crypt::OpenSSL::Guess qw(openssl_inc_paths openssl_lib_paths);
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
 
-print  "LIBS => [" . openssl_lib_paths() . " -lssl -lcrypto\n";
-
 WriteMakefile(
     'NAME'             => 'Crypt::OpenSSL::RSA',
     AUTHOR             => 'Ian Robertson <iroberts@cpan.org>',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,7 @@ WriteMakefile(
         'Test::More'             => 0,
     },
     'OBJECT' => 'RSA.o',
-    'LIBS'   => ( $^O eq 'MSWin32' ) ? [openssl_lib_paths() . ' -lssl32 -leay32'] : [openssl_lib_paths() . ' -lssl -lcrypto'],
+    'LIBS'   => [openssl_lib_paths() . ' -lssl -lcrypto'],
     'DEFINE' => '-DPERL5 -DOPENSSL_NO_KRB5',
 
     # perl-5.8/gcc-3.2 needs -DPERL5, and redhat9 likes -DOPENSSL_NO_KRB5

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,7 @@ WriteMakefile(
         'Test::More'             => 0,
     },
     'OBJECT' => 'RSA.o',
-    'LIBS'   => [openssl_lib_paths() . ' -lssl -lcrypto'],
+    'LIBS'   => ( $^O eq 'MSWin32' ) ? [openssl_lib_paths() . ' -lssl32 -leay32'] : [openssl_lib_paths() . ' -lssl -lcrypto'],
     'DEFINE' => '-DPERL5 -DOPENSSL_NO_KRB5',
 
     # perl-5.8/gcc-3.2 needs -DPERL5, and redhat9 likes -DOPENSSL_NO_KRB5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
 build: off
 
 test_script:
-  - 'prove -l t'
+  - '%perl% Makefile.PL && %make% test'
 
 matrix:
  fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ shallow_clone: true
 environment:
   matrix:
     - perl_type: system
-    - perl_type: strawberry
     - perl_type: cygwin
+    - perl_type: strawberry
     - perl_type: strawberry
       perl_version: 5.24.3.1
     - perl_type: strawberry
@@ -13,6 +13,12 @@ environment:
     - perl_type: strawberry
       perl_version: 5.18.4.1
 install:
+  # use strawberry perl's OpenSSL, remove AppVeyor's buildin OpenSSL-Win32
+  - cmd: if [%perl_type%]==[strawberry] (
+      rd /s /q C:\OpenSSL-Win32 )
+  - cmd: if [%perl_type%]==[cygwin] (
+      C:\cygwin\setup-x86.exe -qgnNdO -l C:\cygwin\var\cache\setup -R c:\cygwin -s http://cygwin.mirror.constant.com -P openssl-devel )
+
   - 'call appveyor.cmd perl_setup'
   - '%perl% -V'
   - '%cpanm% --installdeps -n --with-develop --with-recommends .'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ shallow_clone: true
 
 environment:
   matrix:
-    - perl_type: system
     - perl_type: cygwin
     - perl_type: strawberry
     - perl_type: strawberry

--- a/hints/MSWin32.pl
+++ b/hints/MSWin32.pl
@@ -1,0 +1,3 @@
+use Config;
+$self->{LIBS} = ['-lssleay32 -llibeay32'] if $Config{cc} =~ /cl/;    # msvc with ActivePerl
+$self->{LIBS} = ['-lssl32 -leay32']       if $Config{gccversion};    # gcc

--- a/hints/MSWin32.pl
+++ b/hints/MSWin32.pl
@@ -1,9 +1,10 @@
 use Config;
+use Crypt::OpenSSL::Guess 0.11 qw(openssl_lib_paths);
 if (my $libs = `pkg-config --libs libssl libcrypto 2>nul`) {
   # strawberry perl has pkg-config
-  $self->{LIBS} = [ $libs ];
+  $self->{LIBS} = [openssl_lib_paths() . " $libs"];
 }
 else {
-  $self->{LIBS} = ['-lssleay32 -llibeay32'] if $Config{cc} =~ /cl/; # msvc with ActivePerl
-  $self->{LIBS} = ['-lssl32 -leay32']       if $Config{gccversion}; # gcc
+  $self->{LIBS} = [openssl_lib_paths() . '-lssleay32 -llibeay32'] if $Config{cc} =~ /cl/; # msvc with ActivePerl
+  $self->{LIBS} = [openssl_lib_paths() . '-lssl32 -leay32']       if $Config{gccversion}; # gcc
 }

--- a/hints/MSWin32.pl
+++ b/hints/MSWin32.pl
@@ -1,3 +1,9 @@
 use Config;
-$self->{LIBS} = ['-lssleay32 -llibeay32'] if $Config{cc} =~ /cl/;    # msvc with ActivePerl
-$self->{LIBS} = ['-lssl32 -leay32']       if $Config{gccversion};    # gcc
+if (my $libs = `pkg-config --libs libssl libcrypto 2>nul`) {
+  # strawberry perl has pkg-config
+  $self->{LIBS} = [ $libs ];
+}
+else {
+  $self->{LIBS} = ['-lssleay32 -llibeay32'] if $Config{cc} =~ /cl/; # msvc with ActivePerl
+  $self->{LIBS} = ['-lssl32 -leay32']       if $Config{gccversion}; # gcc
+}

--- a/t/z_pod.t
+++ b/t/z_pod.t
@@ -1,5 +1,9 @@
 # -*- perl -*-
 use Test::More;
+
+plan skip_all => 'This test is only run for the module author'
+  unless -d '.git' || $ENV{IS_MAINTAINER};
+
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
 all_pod_files_ok();


### PR DESCRIPTION
Crypt::OpenSSL::RSA failed to install on strawberry perl 5.26 at [CPAN Testers](http://matrix.cpantesters.org/?dist=Crypt-OpenSSL-RSA%200.29_03;os=mswin32;perl=5.26.0;reports=1).
This PR applies the patch from strawberry perl's: http://strawberryperl.com/package/kmx/perl-modules-patched/Crypt-OpenSSL-Random-0.11_patched.diff

Also the module have dependency for Crypt::OpenSSL::Random, so AppVeyor will fail tests until this change is released https://github.com/rurban/Crypt-OpenSSL-Random/pull/7.
(Update: It has been released. I'm going to retry AppVeyor's test after an hour. https://metacpan.org/release/RURBAN/Crypt-OpenSSL-Random-0.15)