### PR TITLE
Prefix bn2sv function so it doesn't collide with Net::SSLeay

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Crypt::OpenSSL::RSA.
 
+0.32 ??
+    - Prefix internal bn2sv function so it doesn't collide with Net::SSLeay
+
 0.31 Mon Sep 24 2018
     - Remove default of SHA256 for RSA keys. This has caused significant
       problems with downstream modules and it has always been possible to

--- a/RSA.xs
+++ b/RSA.xs
@@ -152,7 +152,7 @@ unsigned char* get_message_digest(SV* text_SV, int hash_method)
     }
 }
 
-SV* bn2sv(const BIGNUM* p_bn)
+SV* cor_bn2sv(const BIGNUM* p_bn)
 {
     return p_bn != NULL
         ? sv_2mortal(newSViv((IV) BN_dup(p_bn)))
@@ -467,14 +467,14 @@ PPCODE:
     RSA_get0_factors(rsa, &p, &q);
     RSA_get0_crt_params(rsa, &dmp1, &dmq1, &iqmp);
 #endif
-    XPUSHs(bn2sv(n));
-    XPUSHs(bn2sv(e));
-    XPUSHs(bn2sv(d));
-    XPUSHs(bn2sv(p));
-    XPUSHs(bn2sv(q));
-    XPUSHs(bn2sv(dmp1));
-    XPUSHs(bn2sv(dmq1));
-    XPUSHs(bn2sv(iqmp));
+    XPUSHs(cor_bn2sv(n));
+    XPUSHs(cor_bn2sv(e));
+    XPUSHs(cor_bn2sv(d));
+    XPUSHs(cor_bn2sv(p));
+    XPUSHs(cor_bn2sv(q));
+    XPUSHs(cor_bn2sv(dmp1));
+    XPUSHs(cor_bn2sv(dmq1));
+    XPUSHs(cor_bn2sv(iqmp));
 }
 
 SV*


### PR DESCRIPTION
Fixes https://github.com/toddr/Crypt-OpenSSL-RSA/issues/18