### PR TITLE
prevent outer $SIG{__DIE__} handler from being called

### DIFF
--- a/RSA.pm
+++ b/RSA.pm
@@ -14,8 +14,11 @@ use XSLoader;
 XSLoader::load 'Crypt::OpenSSL::RSA', $VERSION;
 
 BEGIN {
-    eval { require Crypt::OpenSSL::Bignum };
-}            ## no critic qw(RequireCheckingReturnValueOfEval);
+    eval {
+        local $SIG{__DIE__};    # prevent outer handlers from being called
+        require Crypt::OpenSSL::Bignum;
+    };
+}    ## no critic qw(RequireCheckingReturnValueOfEval);
 
 1;
 

--- a/t/fakelib/Crypt/OpenSSL/Bignum.pm
+++ b/t/fakelib/Crypt/OpenSSL/Bignum.pm
@@ -1,0 +1,3 @@
+package Crypt::OpenSSL::Bignum;
+
+0;    # make require fail

--- a/t/sig_die.t
+++ b/t/sig_die.t
@@ -1,0 +1,15 @@
+use strict;
+use Test::More;
+
+use lib 't/fakelib';
+
+my $handler_called;
+$SIG{__DIE__} = sub { ++$handler_called };
+
+require Crypt::OpenSSL::RSA;
+
+plan tests => 1;
+
+ok !$handler_called, 'outer $SIG{__DIE__} handler not called';
+
+done_testing;

--- a/t/sig_die.t
+++ b/t/sig_die.t
@@ -11,5 +11,3 @@ require Crypt::OpenSSL::RSA;
 plan tests => 1;
 
 ok !$handler_called, 'outer $SIG{__DIE__} handler not called';
-
-done_testing;


### PR DESCRIPTION
in case Crypt::OpenSSL::Bignum is not installed

See `perldoc -f eval`:

                Using the "eval {}" form as an exception trap in libraries
                does have some issues. Due to the current arguably broken
                state of "__DIE__" hooks, you may wish not to trigger any
                "__DIE__" hooks that user code may have installed. You can
                use the "local $SIG{__DIE__}" construct for this purpose, as
                this example shows:

                    # a private exception trap for divide-by-zero
                    eval { local $SIG{'__DIE__'}; $answer = $a / $b; };
                    warn $@ if $@;