### PR TITLE
Ensure that verify() leaves openssl error stack clean on failure

### DIFF
--- a/RSA.xs
+++ b/RSA.xs
@@ -706,7 +706,7 @@ PPCODE:
                       p_rsa->rsa))
     {
         case 0:
-            CHECK_OPEN_SSL(ERR_peek_error());
+            ERR_clear_error();
             XSRETURN_NO;
             break;
         case 1:


### PR DESCRIPTION
Fixes #29