### PR TITLE
Fix for Issue 31

### DIFF
--- a/RSA.pm
+++ b/RSA.pm
@@ -37,7 +37,6 @@ Crypt::OpenSSL::RSA - RSA encoding and decoding, using the openSSL libraries
   Crypt::OpenSSL::Random::random_seed($good_entropy);
   Crypt::OpenSSL::RSA->import_random_seed();
   $rsa_pub = Crypt::OpenSSL::RSA->new_public_key($key_string);
-  $rsa_pub->use_sslv23_padding(); # use_pkcs1_oaep_padding is the default
   $ciphertext = $rsa->encrypt($plaintext);
 
   $rsa_priv = Crypt::OpenSSL::RSA->new_private_key($key_string);
@@ -227,6 +226,8 @@ C<Crypt::OpenSSL::RSA>.
 
 Use C<PKCS #1 v1.5> padding with an SSL-specific modification that
 denotes that the server is SSL3 capable.
+
+Not available since OpenSSL 3.
 
 =item use_md5_hash
 

--- a/RSA.xs
+++ b/RSA.xs
@@ -640,11 +640,15 @@ use_pkcs1_oaep_padding(p_rsa)
   CODE:
     p_rsa->padding = RSA_PKCS1_OAEP_PADDING;
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+
 void
 use_sslv23_padding(p_rsa)
     rsaData* p_rsa;
   CODE:
     p_rsa->padding = RSA_SSLV23_PADDING;
+
+#endif
 
 # Sign text. Returns the signature.
 


### PR DESCRIPTION
Fix Issue #31 by removing reference to RSA_SSLV23_PADDING (removed from OpenSSL starting from v3.0.0)

This is based on kambe-mikb's pull request #32. My commit also patches a documentation.