### PR TITLE
SYNOPSIS says `$plaintext = $rsa->encrypt($ciphertext);`

### DIFF
--- a/RSA.pm
+++ b/RSA.pm
@@ -40,7 +40,7 @@ Crypt::OpenSSL::RSA - RSA encoding and decoding, using the openSSL libraries
   $ciphertext = $rsa->encrypt($plaintext);
 
   $rsa_priv = Crypt::OpenSSL::RSA->new_private_key($key_string);
-  $plaintext = $rsa->encrypt($ciphertext);
+  $plaintext = $rsa->decrypt($ciphertext);
 
   $rsa = Crypt::OpenSSL::RSA->generate_key(1024); # or
   $rsa = Crypt::OpenSSL::RSA->generate_key(1024, $prime);


### PR DESCRIPTION
A typo fix! 

https://github.com/toddr/Crypt-OpenSSL-RSA/blob/01fe9b73040838f63981af879e4f36a7e299b97c/RSA.pm#L43

I think this should likely be:
```perl
$plaintext = $rsa->decrypt($ciphertext);
```